### PR TITLE
[Feat] 공통으로 사용할 UITableView 클래스의 공통 델리게이트 클래스 생성 (#28)

### DIFF
--- a/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
+++ b/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
@@ -10,4 +10,16 @@ class TodoTableViewCell: UITableViewCell {
     static var nib: UINib {
         return UINib(nibName: String(describing: self), bundle: nil)
     }
+
+    func admitCardData(_ card: CardData) {
+        setTitleLabelAttribute(card.title)
+    }
+
+    private func setTitleLabelAttribute(_ text: String) {
+        titleLabel.text = text
+    }
+
+    private func setContentLabelAttribute(_ text: String) {
+        contentLabel.text = text
+    }
 }

--- a/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
+++ b/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
@@ -11,7 +11,7 @@ class TodoTableViewCell: UITableViewCell {
         return UINib(nibName: String(describing: self), bundle: nil)
     }
 
-    func admitCardData(_ card: CardData) {
+    func admitCardLabel(_ card: CardData) {
         setTitleLabelAttribute(card.title)
     }
 

--- a/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
+++ b/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
@@ -11,7 +11,7 @@ class TodoTableViewCell: UITableViewCell {
         return UINib(nibName: String(describing: self), bundle: nil)
     }
 
-    func admitCardLabel(_ card: CardData) {
+    func reloadAllLabels(_ card: CardData) {
         setTitleLabelAttribute(card.title)
     }
 

--- a/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
+++ b/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
@@ -33,7 +33,7 @@ extension ColumnTableViewManagement: UITableViewDataSource {
             return UITableViewCell()
         }
 
-        cell.admitCardLabel(dataSource[indexPath.row])
+        cell.reloadAllLabels(dataSource[indexPath.row])
 
         return cell
     }

--- a/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
+++ b/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
@@ -1,0 +1,44 @@
+//
+// Created by 백상휘 on 2022/04/11.
+//
+
+import UIKit
+
+class ColumnTableViewManagement: NSObject {
+    lazy var dataSource = [CardData]() {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.targetTableView.reloadData()
+            }
+        }
+    }
+
+    private var targetTableView: UITableView!
+
+    convenience init(tableView: UITableView) {
+        self.init()
+        targetTableView = tableView
+    }
+}
+
+extension ColumnTableViewManagement: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        dataSource.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TodoTableViewCell.cellName, for: indexPath) as? TodoTableViewCell else {
+            return UITableViewCell()
+        }
+
+        cell.admitCardData(dataSource[indexPath.row])
+
+        return cell
+    }
+}
+
+extension ColumnTableViewManagement: UITableViewDelegate {
+
+}

--- a/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
+++ b/Client/iOS/TodoList/ViewControllers/ColumnTableViewManagement.swift
@@ -33,7 +33,7 @@ extension ColumnTableViewManagement: UITableViewDataSource {
             return UITableViewCell()
         }
 
-        cell.admitCardData(dataSource[indexPath.row])
+        cell.admitCardLabel(dataSource[indexPath.row])
 
         return cell
     }


### PR DESCRIPTION
## 💡 관련 이슈

- #28 

## 내용

* ColumnTableViewManagement.swift 를 생성하였습니다.
  * 현재는 UITableViewDelegate의 역할이 없어서 두 개를 합쳐 놓았습니다.
  * 이는 차후에 UITableViewDataSource와 따로 나뉠 수 있습니다.

* TodoTableViewCell 클래스에 카드 데이터를 이용하여 텍스트를 입력할 수 있도록 하였습니다.