### PR TITLE
[Refactor] CardsFetchingDataTask 리펙토링 (#23)

### DIFF
--- a/Client/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/Client/iOS/TodoList.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6FD8AB5A2804268800A4B350 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB432803C78400A4B350 /* SessionDataTask.swift */; };
 		6FD8AB5B280426A400A4B350 /* SessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB422803C78400A4B350 /* SessionConfiguration.swift */; };
 		6FD8AB5C280426B000A4B350 /* SessionCommonAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB4B2803C78400A4B350 /* SessionCommonAttributes.swift */; };
+		6FD8AB5D28048E4700A4B350 /* CardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB482803C78400A4B350 /* CardData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -377,6 +378,7 @@
 				6FD8AB3C2803C68B00A4B350 /* CardAPITests.swift in Sources */,
 				6F5BC2A027FA9CB6002D591D /* TodoListTests.swift in Sources */,
 				6FD8AB5C280426B000A4B350 /* SessionCommonAttributes.swift in Sources */,
+				6FD8AB5D28048E4700A4B350 /* CardData.swift in Sources */,
 				6FD8AB582804218400A4B350 /* CardsFetchingDataTask.swift in Sources */,
 				6FD8AB592804268400A4B350 /* CardHTTPRequest.swift in Sources */,
 			);

--- a/Client/iOS/TodoList.xcodeproj/project.pbxproj
+++ b/Client/iOS/TodoList.xcodeproj/project.pbxproj
@@ -20,6 +20,23 @@
 		6F5BC29527FA9CB6002D591D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6F5BC29327FA9CB6002D591D /* LaunchScreen.storyboard */; };
 		6F5BC2A027FA9CB6002D591D /* TodoListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5BC29F27FA9CB6002D591D /* TodoListTests.swift */; };
 		6F5BC2AB27FA9CB6002D591D /* TodoListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5BC2AA27FA9CB6002D591D /* TodoListUITests.swift */; };
+		6FD8AB3C2803C68B00A4B350 /* CardAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB3B2803C68B00A4B350 /* CardAPITests.swift */; };
+		6FD8AB4C2803C78400A4B350 /* CardHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB412803C78400A4B350 /* CardHTTPRequest.swift */; };
+		6FD8AB4D2803C78400A4B350 /* SessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB422803C78400A4B350 /* SessionConfiguration.swift */; };
+		6FD8AB4E2803C78400A4B350 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB432803C78400A4B350 /* SessionDataTask.swift */; };
+		6FD8AB4F2803C78400A4B350 /* RequestSessionDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB442803C78400A4B350 /* RequestSessionDefault.swift */; };
+		6FD8AB502803C78400A4B350 /* CardsUpdateDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB452803C78400A4B350 /* CardsUpdateDataTask.swift */; };
+		6FD8AB512803C78400A4B350 /* CardsFetchingDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB462803C78400A4B350 /* CardsFetchingDataTask.swift */; };
+		6FD8AB522803C78400A4B350 /* CardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB482803C78400A4B350 /* CardData.swift */; };
+		6FD8AB532803C78400A4B350 /* BoardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB492803C78400A4B350 /* BoardData.swift */; };
+		6FD8AB542803C78400A4B350 /* HistoryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB4A2803C78400A4B350 /* HistoryData.swift */; };
+		6FD8AB552803C78400A4B350 /* SessionCommonAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB4B2803C78400A4B350 /* SessionCommonAttributes.swift */; };
+		6FD8AB572803C7A100A4B350 /* SystemLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB562803C7A100A4B350 /* SystemLog.swift */; };
+		6FD8AB582804218400A4B350 /* CardsFetchingDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB462803C78400A4B350 /* CardsFetchingDataTask.swift */; };
+		6FD8AB592804268400A4B350 /* CardHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB412803C78400A4B350 /* CardHTTPRequest.swift */; };
+		6FD8AB5A2804268800A4B350 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB432803C78400A4B350 /* SessionDataTask.swift */; };
+		6FD8AB5B280426A400A4B350 /* SessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB422803C78400A4B350 /* SessionConfiguration.swift */; };
+		6FD8AB5C280426B000A4B350 /* SessionCommonAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8AB4B2803C78400A4B350 /* SessionCommonAttributes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +76,18 @@
 		6F5BC2A627FA9CB6002D591D /* TodoListUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TodoListUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F5BC2AA27FA9CB6002D591D /* TodoListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListUITests.swift; sourceTree = "<group>"; };
 		6F5BC2AC27FA9CB6002D591D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6FD8AB3B2803C68B00A4B350 /* CardAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardAPITests.swift; sourceTree = "<group>"; };
+		6FD8AB412803C78400A4B350 /* CardHTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardHTTPRequest.swift; sourceTree = "<group>"; };
+		6FD8AB422803C78400A4B350 /* SessionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConfiguration.swift; sourceTree = "<group>"; };
+		6FD8AB432803C78400A4B350 /* SessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
+		6FD8AB442803C78400A4B350 /* RequestSessionDefault.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSessionDefault.swift; sourceTree = "<group>"; };
+		6FD8AB452803C78400A4B350 /* CardsUpdateDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsUpdateDataTask.swift; sourceTree = "<group>"; };
+		6FD8AB462803C78400A4B350 /* CardsFetchingDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsFetchingDataTask.swift; sourceTree = "<group>"; };
+		6FD8AB482803C78400A4B350 /* CardData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardData.swift; sourceTree = "<group>"; };
+		6FD8AB492803C78400A4B350 /* BoardData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoardData.swift; sourceTree = "<group>"; };
+		6FD8AB4A2803C78400A4B350 /* HistoryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryData.swift; sourceTree = "<group>"; };
+		6FD8AB4B2803C78400A4B350 /* SessionCommonAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionCommonAttributes.swift; sourceTree = "<group>"; };
+		6FD8AB562803C7A100A4B350 /* SystemLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemLog.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +157,8 @@
 		6F5BC28727FA9CB0002D591D /* TodoList */ = {
 			isa = PBXGroup;
 			children = (
+				6FD8AB562803C7A100A4B350 /* SystemLog.swift */,
+				6FD8AB402803C78400A4B350 /* Network */,
 				6F1EC59627FD5B0800BAED63 /* Cells */,
 				6F13F36F27FC2D31000DF2BA /* ViewControllers */,
 				6F5BC28827FA9CB0002D591D /* AppDelegate.swift */,
@@ -144,6 +175,7 @@
 		6F5BC29E27FA9CB6002D591D /* TodoListTests */ = {
 			isa = PBXGroup;
 			children = (
+				6FD8AB3B2803C68B00A4B350 /* CardAPITests.swift */,
 				6F5BC29F27FA9CB6002D591D /* TodoListTests.swift */,
 				6F5BC2A127FA9CB6002D591D /* Info.plist */,
 			);
@@ -157,6 +189,31 @@
 				6F5BC2AC27FA9CB6002D591D /* Info.plist */,
 			);
 			path = TodoListUITests;
+			sourceTree = "<group>";
+		};
+		6FD8AB402803C78400A4B350 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				6FD8AB412803C78400A4B350 /* CardHTTPRequest.swift */,
+				6FD8AB422803C78400A4B350 /* SessionConfiguration.swift */,
+				6FD8AB432803C78400A4B350 /* SessionDataTask.swift */,
+				6FD8AB442803C78400A4B350 /* RequestSessionDefault.swift */,
+				6FD8AB452803C78400A4B350 /* CardsUpdateDataTask.swift */,
+				6FD8AB462803C78400A4B350 /* CardsFetchingDataTask.swift */,
+				6FD8AB472803C78400A4B350 /* ResourcesNetwork */,
+				6FD8AB4B2803C78400A4B350 /* SessionCommonAttributes.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		6FD8AB472803C78400A4B350 /* ResourcesNetwork */ = {
+			isa = PBXGroup;
+			children = (
+				6FD8AB482803C78400A4B350 /* CardData.swift */,
+				6FD8AB492803C78400A4B350 /* BoardData.swift */,
+				6FD8AB4A2803C78400A4B350 /* HistoryData.swift */,
+			);
+			path = ResourcesNetwork;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -293,9 +350,20 @@
 				6F1EC59927FD5B4500BAED63 /* TodoTableViewCell.swift in Sources */,
 				6F13F36D27FC2487000DF2BA /* TodoViewController.swift in Sources */,
 				6F5BC28D27FA9CB0002D591D /* ViewController.swift in Sources */,
+				6FD8AB522803C78400A4B350 /* CardData.swift in Sources */,
+				6FD8AB512803C78400A4B350 /* CardsFetchingDataTask.swift in Sources */,
+				6FD8AB532803C78400A4B350 /* BoardData.swift in Sources */,
+				6FD8AB4C2803C78400A4B350 /* CardHTTPRequest.swift in Sources */,
+				6FD8AB552803C78400A4B350 /* SessionCommonAttributes.swift in Sources */,
+				6FD8AB4F2803C78400A4B350 /* RequestSessionDefault.swift in Sources */,
+				6FD8AB542803C78400A4B350 /* HistoryData.swift in Sources */,
+				6FD8AB502803C78400A4B350 /* CardsUpdateDataTask.swift in Sources */,
 				6F5BC28927FA9CB0002D591D /* AppDelegate.swift in Sources */,
+				6FD8AB4E2803C78400A4B350 /* SessionDataTask.swift in Sources */,
+				6FD8AB572803C7A100A4B350 /* SystemLog.swift in Sources */,
 				6F5BC28B27FA9CB0002D591D /* SceneDelegate.swift in Sources */,
 				6F13F37627FC9C0A000DF2BA /* CompletedTodoViewController.swift in Sources */,
+				6FD8AB4D2803C78400A4B350 /* SessionConfiguration.swift in Sources */,
 				6F13F37427FC9BD3000DF2BA /* ProgressTodoViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -304,7 +372,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FD8AB5A2804268800A4B350 /* SessionDataTask.swift in Sources */,
+				6FD8AB5B280426A400A4B350 /* SessionConfiguration.swift in Sources */,
+				6FD8AB3C2803C68B00A4B350 /* CardAPITests.swift in Sources */,
 				6F5BC2A027FA9CB6002D591D /* TodoListTests.swift in Sources */,
+				6FD8AB5C280426B000A4B350 /* SessionCommonAttributes.swift in Sources */,
+				6FD8AB582804218400A4B350 /* CardsFetchingDataTask.swift in Sources */,
+				6FD8AB592804268400A4B350 /* CardHTTPRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -473,6 +547,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TodoList/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -492,6 +567,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TodoList/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
+++ b/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
@@ -40,11 +40,11 @@ class DataTask<T: Codable>: CardHTTPRequest {
         }
         doGetRequest(url: url, parameter: nil) { [weak self] taskResult in
             guard let data = try? taskResult.get() else {
-                completionHandler(.failure(.failureConnect))
+                completionHandler(.failure(.notConnect))
                 return
             }
             guard let decodedData = try? self?.decoder.decode([[T]].self, from: data) else {
-                completionHandler(.failure(.decode))
+                completionHandler(.failure(.notConvertdecode))
                 return
             }
             completionHandler(.success(decodedData))
@@ -58,11 +58,11 @@ class DataTask<T: Codable>: CardHTTPRequest {
         }
         doGetRequest(url: url, parameter: nil) { [weak self] taskResult in
             guard let data = try? taskResult.get() else {
-                completionHandler(.failure(.failureConnect))
+                completionHandler(.failure(.notConnect))
                 return
             }
             guard let decodedData = try? self?.decoder.decode([T].self, from: data) else {
-                completionHandler(.failure(.decode))
+                completionHandler(.failure(.notConvertdecode))
                 return
             }
             completionHandler(.success(decodedData))
@@ -81,9 +81,9 @@ enum URLType: CustomStringConvertible {
 }
 
 enum DataTaskError: Error {
-    case failureConnect
+    case notConnect
     case invalidURL
-    case decode
+    case notConvertdecode
 }
 
 // MARK:- ServerAPI

--- a/Client/iOS/TodoListTests/CardAPITests.swift
+++ b/Client/iOS/TodoListTests/CardAPITests.swift
@@ -9,17 +9,65 @@ import XCTest
 @testable import TodoList
 
 class CardAPITests: XCTestCase {
+    
+    struct MockAPI: ServerAPI {
+        let endpoint: String = "https://naver.com"
+    }
+    
+    var task: DataTask<CardData>!
+    
+    override func setUpWithError() throws {
+        let task = DataTask(api: Team13API(), dataType: CardData.self)
+        self.task = task
+    }
 
-    let httpRequest = CardHTTPRequest(
-        as: "https://www.naver.com",
-        using: nil,
-        in: OperationQueue.main,
-        type: .default
-    )
+    override func tearDownWithError() throws {
+        self.task = nil
+    }
+    
+    func test_todolistAPI_connectionSuccess_getData() throws {
+        let expectation = XCTestExpectation()
+        task?.fetchCardsAll(completionHandler: { result in
+            switch result {
+            case .success(let data):
+                XCTAssertNotNil(data)
+            case .failure(let error):
+                XCTFail("todolist request Failed \(error.localizedDescription)")
+            }
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 2.0)
+    }
+    
     
     func test_requestInterfaceConnected_getData() throws {
-        
-        // 현재 API가 전달되지 않아서 URLProtocol로 대신합니다.
+        let request = CardHTTPRequest(
+            as: "http://13.125.216.180:8080/todolist/3",
+            using: nil,
+            in: OperationQueue.main,
+            type: .default
+        )
+
+        let expectation = XCTestExpectation()
+        request?.doGetRequest(parameter: nil, completionHandler: { result in
+            switch result {
+            case .success(let data):
+                XCTAssertNotNil(data)
+            case .failure(let error):
+                XCTFail("todolist request Failed")
+            }
+            expectation.fulfill()
+        })
+        wait(for: [expectation], timeout: 2.0)
+    }
+    
+    func test_requestInterfaceConnected_getMockData() throws {
+        let httpRequest = CardHTTPRequest(
+            as: "https://www.naver.com",
+            using: nil,
+            in: OperationQueue.main,
+            type: .default
+        )
         httpRequest?.config.protocolClasses = [MockURLProtocol.self]
         
         let expectation = XCTestExpectation(description: "Wait")

--- a/Client/iOS/TodoListTests/CardAPITests.swift
+++ b/Client/iOS/TodoListTests/CardAPITests.swift
@@ -14,10 +14,10 @@ class CardAPITests: XCTestCase {
         let endpoint: String = "https://naver.com"
     }
     
-    var task: DataTask<CardData>!
+    var task: DataTask!
     
     override func setUpWithError() throws {
-        let task = DataTask(api: Team13API(), dataType: CardData.self)
+        let task = DataTask(api: Team13API())
         self.task = task
     }
 
@@ -27,7 +27,7 @@ class CardAPITests: XCTestCase {
     
     func test_todolistAPI_connectionSuccess_getData() throws {
         let expectation = XCTestExpectation()
-        task?.fetchCardsAll(completionHandler: { result in
+        task?.fetchAll(dataType: Cards.self, completionHandler: { result in
             switch result {
             case .success(let data):
                 XCTAssertNotNil(data)
@@ -36,7 +36,7 @@ class CardAPITests: XCTestCase {
             }
             expectation.fulfill()
         })
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 3.0)
     }
     
     


### PR DESCRIPTION
# 💡 Issue

- #23 

# 📝 Tasks

- [ ] API 호출 클래스를 테스트 가능하도록 모듈화하기
- [x] Test /todolist API 테스트

### 🔹 고민과 해결 
- CardsFetchingDataTask 를 테스트 했을때 실패가 뜹니다
  - 어디서 에러가 나는지 디버깅 필요 => 찾음! 서버에서 내려준 키값과 decoding 할 구조체 키값이 달라서 생긴 문제
- CardsFetchingDataTask 클래스 테스트 가능하도록 수정
  - 타입, URL 을 인자로 받아서 클래스 초기화 하도록 변경
  - API 호출시 인자값을 적게 받아 사용할 수 있는점에 중점을 둠