### PR TITLE
[Feat] 서버에 유저정보를 보내 인증 (#22)

### DIFF
--- a/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
+++ b/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
@@ -31,6 +31,31 @@ class DataTask: SessionDataTask {
         super.init(as: urlString, using: delegate, in: queue, type: type)
     }
     
+    func fetchUser(completionHandler: @escaping (Result<String,DataTaskError>) -> Void) {
+        guard let url = api.toURL(type: .user) else {
+            completionHandler(.failure(.invalidURL))
+            return
+        }
+        let request = URLRequest(url: url)
+        self.session.dataTask(with: request) { data, response, error in
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+               let fields = httpResponse.allHeaderFields as? [String: String] else {
+                completionHandler(.failure(.notConvertdecode))
+                return
+            }
+
+            let cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
+            HTTPCookieStorage.shared.setCookies(cookies, for: response?.url, mainDocumentURL: nil)
+            guard let cookie_userId = cookies.filter({ $0.name == "userId" }).first else {
+                completionHandler(.failure(.notConvertdecode))
+                return
+            }
+            completionHandler(.success(cookie_userId.value))
+        }.resume()
+    }
+    
+    
     func fetchAll<T: Codable>(dataType: T.Type, completionHandler: @escaping (Result<T,DataTaskError>) -> Void) {
         guard let url = api.toURL(type: .all) else {
             completionHandler(.failure(.invalidURL))
@@ -89,7 +114,7 @@ protocol ServerAPI {
 extension ServerAPI {
     func getUrlString(type: URLType) -> String {
         switch type {
-        case .all:
+        case .all, .user:
             return endpoint+"\(type)"
         }
     }
@@ -104,10 +129,13 @@ extension ServerAPI {
 
 enum URLType: CustomStringConvertible {
     case all
+    case user
     var description: String {
         switch self {
         case .all:
             return "/todolist"
+        case .user:
+            return "/user"
         }
     }
 }

--- a/Client/iOS/TodoListTests/CardAPITests.swift
+++ b/Client/iOS/TodoListTests/CardAPITests.swift
@@ -25,6 +25,21 @@ class CardAPITests: XCTestCase {
         self.task = nil
     }
     
+    func test_userAPI_connectionSuccess_getCookie() {
+        let expectation = XCTestExpectation()
+        task.fetchUser { result in
+            switch result {
+            case .success(let userId):
+                XCTAssertNotNil(userId)
+            case .failure(let error):
+                XCTFail("Failed get user cookie \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+    }
+    
+    
     func test_todolistAPI_connectionSuccess_getData() throws {
         let expectation = XCTestExpectation()
         task?.fetchAll(dataType: Cards.self, completionHandler: { result in

--- a/Client/iOS/TodoListTests/CardAPITests.swift
+++ b/Client/iOS/TodoListTests/CardAPITests.swift
@@ -42,7 +42,7 @@ class CardAPITests: XCTestCase {
     
     func test_todolistAPI_connectionSuccess_getData() throws {
         let expectation = XCTestExpectation()
-        task?.fetchAll(dataType: Cards.self, completionHandler: { result in
+        task?.fetchAll(dataType: CardMap.self, completionHandler: { result in
             switch result {
             case .success(let data):
                 XCTAssertNotNil(data)


### PR DESCRIPTION
# 💡 Issue
- #22 

# 📝 Tasks
- [x] 서버에 /user API 를 호출해서 userId 에 대한 정보를 쿠키로 받아온다
- [x] 받아온 쿠키 정보를 /todolist 요청시 header 에 넣어 보낸다

### 🔹 고민과 해결 

- 쿠키를 어떻게 넣는지 검색하다 HTTPCookie, HTTPCookieStorage 객체를 사용해 편리하게 사용할 수 있다는 것을 알았습니다
- HTTPCookieStorage 객체는 싱글톤으로 구현되어 한번 받아온 쿠키값을 저장해 뒀다가 꺼내쓸 수 있었습니다.
- HTTPCookie 객체는 request 의 header 필드에 쿠키값을 `키:값` 형태로 편리하게 넣을 수 있는 함수를 제공해 줬습니다