### PR TITLE
[Feat] 사용자 쿠키가 반영된 API 연결 & 화면 업데이트

### DIFF
--- a/Client/iOS/TodoList/AppDelegate.swift
+++ b/Client/iOS/TodoList/AppDelegate.swift
@@ -10,9 +10,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    static let middleWare = CardDataMiddleWare {
+    static let middleWare = CardDataMiddleWare(persistenceProvider: BoardPersistenceProvider()) {
         DebugDataTask(api: Team13API())
     }
-    
 }
-

--- a/Client/iOS/TodoList/AppDelegate.swift
+++ b/Client/iOS/TodoList/AppDelegate.swift
@@ -10,7 +10,20 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
+    static let dataTask = DataTask(api: Team13API())
     static let middleWare = CardDataMiddleWare(persistenceProvider: BoardPersistenceProvider()) {
-        DebugDataTask(api: Team13API())
+            dataTask
+    }
+    
+    func applicationDidFinishLaunching(_ application: UIApplication) {
+        // TODO:- 사용자 쿠키를 받아오지 못했을때 처리
+        Self.dataTask?.fetchUser(completionHandler: { result in
+            switch result {
+            case .success:
+                break
+            case .failure:
+                break
+            }
+        })
     }
 }

--- a/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
+++ b/Client/iOS/TodoList/Cells/TodoTableViewCell.swift
@@ -20,7 +20,7 @@ class TodoTableViewCell: UITableViewCell {
         roundedView.layer.masksToBounds = true
     }
     
-    func applyTextAllLabels(data card: CardData) {
+    func applyTextAllLabels(data card: Card) {
         setTitleLabelAttribute(card.title)
         setContentLabelAttribute(card.contents)
     }

--- a/Client/iOS/TodoList/DB/PersistenceProvider.swift
+++ b/Client/iOS/TodoList/DB/PersistenceProvider.swift
@@ -37,10 +37,6 @@ protocol PersistenceProvider {
 
 
 class BoardPersistenceProvider: PersistenceProvider {
-    static var shared = BoardPersistenceProvider()
-    
-    private init() {}
-        
     private lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Model")
         container.loadPersistentStores { description, error in

--- a/Client/iOS/TodoList/DB/PersistenceProvider.swift
+++ b/Client/iOS/TodoList/DB/PersistenceProvider.swift
@@ -3,9 +3,9 @@ import CoreData
 
 // MARK:- Cards
 struct Card {
-    let cardId: Int
-    let cardTitle: String
-    let cardContent: String
+    let id: Int
+    let title: String
+    let contents: String
     let boardName: String
 }
 
@@ -32,6 +32,7 @@ enum BoardType: CustomStringConvertible {
 // MARK:- DataManager
 protocol PersistenceProvider {
     func insertCard(boardType: BoardType, id: Int, title: String, content: String)
+    func insertBoard(type: BoardType, cards: [Card])
     func fetchAllCard(where boardType: BoardType) -> [Card]
 }
 
@@ -55,6 +56,17 @@ class BoardPersistenceProvider: PersistenceProvider {
         return NSEntityDescription.entity(forEntityName: "TaskBoard", in: context)
     }
     
+    func insertBoard(type: BoardType, cards: [Card]) {
+        let fetchAllCard = fetchAllCard(where: type)
+        for card in cards {
+            if fetchAllCard.contains(where: { $0.id == card.id }) {
+                // TODO:- id 가 같지만 수정되어 필드값이 하나라도 다를 수 있다 -> 모든 필드가 같은지 비교 필요
+                continue
+            }
+            insertCard(boardType: type, id: card.id, title: card.title, content: card.contents)
+        }
+    }
+    
     func insertCard(boardType: BoardType, id: Int, title: String, content: String) {
         guard let entity = entity else {
             return
@@ -71,7 +83,8 @@ class BoardPersistenceProvider: PersistenceProvider {
         do {
             let fetchResults = try context.fetch(TaskBoard.fetchRequest()) as! [TaskBoard]
             let results = fetchResults
-                .map{ Card.init(cardId: Int($0.cardId), cardTitle: $0.title!, cardContent: $0.content!, boardName: $0.type!) }
+                .map{ Card(id: Int($0.cardId), title: $0.title!, contents: $0.content!, boardName: $0.type!) }
+            
             if boardType == .all {
                 return results
             }

--- a/Client/iOS/TodoList/DB/PersistenceProvider.swift
+++ b/Client/iOS/TodoList/DB/PersistenceProvider.swift
@@ -16,7 +16,16 @@ enum BoardType: CustomStringConvertible {
     case done
     
     var description: String {
-        return "\(self)"
+        switch self {
+        case .todo:
+            return "TODO"
+        case .progress:
+            return "DOING"
+        case .done:
+            return "DONE"
+        default:
+            return ""
+        }
     }
 }
 
@@ -55,7 +64,7 @@ class BoardPersistenceProvider: PersistenceProvider {
             return
         }
         let object = NSManagedObject(entity: entity, insertInto: context)
-        object.setValue(boardType, forKey: "type")
+        object.setValue(boardType.description, forKey: "type")
         object.setValue(id, forKey: "cardId")
         object.setValue(content, forKey: "content")
         object.setValue(title, forKey: "title")

--- a/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
+++ b/Client/iOS/TodoList/Network/CardsFetchingDataTask.swift
@@ -11,8 +11,13 @@ struct Team13API: ServerAPI {
     let endpoint: String = "http://13.125.216.180:8080"
 }
 
+protocol APIService {
+    func fetchUser(completionHandler: @escaping (Result<String,DataTaskError>) -> Void)
+    func fetchAll<T: Codable>(dataType: T.Type, completionHandler: @escaping (Result<T,DataTaskError>) -> Void)
+}
 
-class DataTask: SessionDataTask {
+
+class DataTask: SessionDataTask, APIService {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private let api: ServerAPI

--- a/Client/iOS/TodoList/Network/ResourcesNetwork/CardMap.swift
+++ b/Client/iOS/TodoList/Network/ResourcesNetwork/CardMap.swift
@@ -11,6 +11,6 @@ struct CardMap: Codable {
     var cardMap: TodoList
     
     struct TodoList: Codable {
-        var todo: [CardData]
+        var TODO: [CardData]
     }
 }

--- a/Client/iOS/TodoList/Repository/CardDataMiddleWare.swift
+++ b/Client/iOS/TodoList/Repository/CardDataMiddleWare.swift
@@ -2,11 +2,9 @@ import UIKit
 
 class CardDataMiddleWare {
     
-    private var fetchResultInBoard = [TodoBoard: Result<[CardData], DataTaskError>]() {
+    private var fetchResultInBoard = [TodoBoard: Result<[Card], DataTaskError>]() {
         willSet {
-            
             for board in newValue.keys {
-                
                 guard let result = newValue[board] else { continue }
                 NotificationCenter
                     .default
@@ -15,42 +13,45 @@ class CardDataMiddleWare {
                         object: self,
                         userInfo: ["result":result]
                     )
-                
             }
         }
     }
-    private var dataTask: DebugDataTask?
+    private var dataTask: APIService?
+    private let persistenceProvider: PersistenceProvider?
     
-    init(_ dataTaskGenerator: ()->DebugDataTask?) {
+    init(persistenceProvider: PersistenceProvider, dataTaskGenerator: ()-> APIService?) {
+        self.persistenceProvider = persistenceProvider
         self.dataTask = dataTaskGenerator()
     }
     
     func fetchAllCards() {
+        guard let resultFromCoredata = persistenceProvider?.fetchAllCard(where: .all) else {
+            return
+        }
+        
         dataTask?.fetchAll(dataType: CardMap.self) { [weak self] (result: Result<CardMap, DataTaskError>) in
-            
             guard let self = self else { return }
-            
+
             for board in TodoBoard.allCases {
-                
                 switch result {
-                    
                 case .success(let cardMap):
-                    
-                    self.fetchResultInBoard[board] = Result.success(cardMap.cardMap.todo)
+                    let todos = cardMap.cardMap.TODO.map{ Card(id: $0.id, title: $0.title, contents: $0.contents, boardName: $0.boardName) }
+                    // TODO:- board의 이름에 따라 type값이 달라져야 한다
+                    self.persistenceProvider?.insertBoard(type: .todo, cards: todos)
+                    self.fetchResultInBoard[board] = Result.success(todos)
                     
                 case .failure(let error):
-                    
                     Log.error(error)
+                    self.fetchResultInBoard[board] = Result.success(resultFromCoredata)
                 }
             }
         }
     }
     
-    func getCards(in board: TodoBoard) -> Result<[CardData], DataTaskError> {
+    func getCards(in board: TodoBoard) -> Result<[Card], DataTaskError> {
         guard fetchResultInBoard.keys.contains(board), let result = fetchResultInBoard[board] else {
             return Result.failure(DataTaskError.notConnect)
         }
-        
         return result
     }
 }

--- a/Client/iOS/TodoList/SceneDelegate.swift
+++ b/Client/iOS/TodoList/SceneDelegate.swift
@@ -14,10 +14,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let _ = (scene as? UIWindowScene) else { return }
-        
-        if let rootViewController = window?.rootViewController as? ViewController {
-            rootViewController.setDataManager(BoardPersistenceProvider.shared)
-        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Client/iOS/TodoList/SceneDelegate.swift
+++ b/Client/iOS/TodoList/SceneDelegate.swift
@@ -13,10 +13,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
+        
+        if let rootViewController = window?.rootViewController as? ViewController {
+            rootViewController.setDataManager(BoardPersistenceProvider.shared)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Client/iOS/TodoList/View/TodoRepositoryRespondWrapper.swift
+++ b/Client/iOS/TodoList/View/TodoRepositoryRespondWrapper.swift
@@ -9,7 +9,7 @@ class TodoRepositoryRespondWrapper: NSObject {
     var todoTableView: TodoTableView
     var todoBoard: TodoBoard
     
-    private(set) var dataSource = [CardData]()
+    private(set) var dataSource = [Card]()
     var badgeDelegate: TodoBadgeDelegate?
     
     init(_ tableView: TodoTableView, in board: TodoBoard) {
@@ -28,7 +28,7 @@ class TodoRepositoryRespondWrapper: NSObject {
             
             guard
                 let info = noti.userInfo,
-                let result = info["result"] as? Result<[CardData], DataTaskError>
+                let result = info["result"] as? Result<[Card], DataTaskError>
             else {
                 return
             }
@@ -51,13 +51,13 @@ class TodoRepositoryRespondWrapper: NSObject {
         return (0..<dataSource.count ~= index)
     }
     
-    func insertDataSource(data: CardData, at index: Int) {
+    func insertDataSource(data: Card, at index: Int) {
         guard isEnableIndex(index) else { return }
         dataSource[index] = data
         reloadTodoTableView()
     }
     
-    func setDataSource(data: [CardData]) {
+    func setDataSource(data: [Card]) {
         dataSource = data
         reloadTodoTableView()
     }

--- a/Client/iOS/TodoList/ViewControllers/ViewController.swift
+++ b/Client/iOS/TodoList/ViewControllers/ViewController.swift
@@ -6,6 +6,8 @@ protocol TodoEndPointViewController {
 }
 
 class ViewController: UIViewController {
+    private var dataManager: PersistenceProvider?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -13,6 +15,10 @@ class ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         AppDelegate.middleWare.fetchAllCards()
+    }
+    
+    func setDataManager(_ manager: PersistenceProvider) {
+        self.dataManager = manager
     }
 }
 

--- a/Client/iOS/TodoList/ViewControllers/ViewController.swift
+++ b/Client/iOS/TodoList/ViewControllers/ViewController.swift
@@ -6,7 +6,6 @@ protocol TodoEndPointViewController {
 }
 
 class ViewController: UIViewController {
-    private var dataManager: PersistenceProvider?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,10 +14,6 @@ class ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         AppDelegate.middleWare.fetchAllCards()
-    }
-    
-    func setDataManager(_ manager: PersistenceProvider) {
-        self.dataManager = manager
     }
 }
 


### PR DESCRIPTION
# 💡 Issue
- CoreData 를 앱 초기화할때 연결한다

# 📝 Tasks
- [x] CoreData 연결
- [x] 사용자쿠키값을 앱 초기화할때 받아온다
- [x] 사용자 쿠키값을 반영한 전체 데이터 get API 호출
- [x] 응답을 CoreData 에 저장 (sync)
- [x] 가져온 전체 데이터를 화면에 반영

## CoreData 연결

### 🔹 고민 => 해결!
- coreData 에서 데이터를 읽어와서 화면에 뿌려주는 곳은 CardDataMiddleWare 일까요?
- 현재 네트워크에서 불러오는 작업이 CardDataMiddleWare.fetchAllCards 메서드에 정의가 되어 있는데
- 네트워크에서 불러오고 나서 -> 불러온 값을 core data 에 저장 -> fetchResultInBoard 멤버변수에 들고온 데이터를 set -> Noti를 통해 화면이 업데이트 된다
- 이 순서가 맞을까요?

## API 로 가져온 데이터를 CoreData 에 반영
### 🔹 고민
- API 에서 가져온 데이터를 앱 내부(CoreData) 와 비교해 싱크를 맞춰줘야 하는 작업
- 현재 id 값만 비교해 중복된 id 가 CoreData 에 있으면 CoreData 에 저장하지 않는 로직입니다
- 만약에 필드값이 하나라도 다르면 서버에서 가져온 데이터를 CoreData 에 반영해야 합니다
- 필드값 하나하나를 비교해 다른 데이터인지 판별하는 방법은 비효율적이라는 생각이 듭니다
- 싱크를 어떻게 맞춰야 할지 고민입니다